### PR TITLE
Fix broken lists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
-  "name": "@instantish/martian",
-  "version": "1.0.3",
+  "name": "markdown-to-notion",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@instantish/martian",
-      "version": "1.0.3",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "@notionhq/client": "^0.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
-  "name": "markdown-to-notion",
-  "version": "1.0.0",
+  "name": "@instantish/martian",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "name": "@instantish/martian",
+      "version": "1.0.3",
       "license": "ISC",
       "dependencies": {
         "@notionhq/client": "^0.1.9",

--- a/src/@types/third-party.d.ts
+++ b/src/@types/third-party.d.ts
@@ -1,0 +1,7 @@
+declare module 'storybook-router' {
+  global {
+    interface Window {
+      location: object;
+    }
+  }
+}

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -80,7 +80,7 @@ function parseList(
 )[] {
   return element.children.flatMap(item => {
     const paragraph = item.children[0];
-    if (paragraph.type !== 'paragraph') {
+    if (!paragraph || paragraph.type !== 'paragraph') {
       return [] as (
         | notion.BulletedListItemBlock
         | notion.NumberedListItemBlock

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -23,6 +23,20 @@ hello _world_
     expect(expected).toStrictEqual(actual);
   });
 
+  it('should convert markdown to blocks - deal with broken lists', () => {
+    const text = `
+## broken list
+1. Hello
+2.
+`;
+    const actual = markdownToBlocks(text.toString());
+    const expected = [
+      notion.headingTwo([notion.richText('broken list')]),
+      notion.numberedListItem([notion.richText('Hello')]),
+    ];
+    expect(expected).toStrictEqual(actual);
+  });
+
   it('should convert markdown to rich text', () => {
     const text = 'hello [_url_](https://example.com)';
     const actual = markdownToRichText(text);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
   },
   "include": [
     "src/**/*.ts",
+    "src/@types/*",
     "test/**/*.ts"
   ]
 }


### PR DESCRIPTION
Addresses a bug with lists that are empty and cause the parser to crash.

Note:  I had an issue with types, and had to add a definition to fix it, if there is a better solution please let me know and I will fix it!