### PR TITLE
Multiple newlines fix

### DIFF
--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -200,10 +200,17 @@ export function parseBlocks(
 }
 
 export function parseRichText(root: md.Root): notion.RichText[] {
-  if (root.children.length !== 1 || root.children[0].type !== 'paragraph') {
+  if (root.children[0].type !== 'paragraph') {
     throw new Error(`Unsupported markdown element: ${JSON.stringify(root)}`);
   }
 
-  const paragraph = root.children[0];
-  return paragraph.children.flatMap(child => parseInline(child));
+  const richTexts: notion.RichText[] = [];
+  root.children.forEach(paragraph => {
+    if (paragraph.type === 'paragraph') {
+      paragraph.children.forEach(child =>
+        richTexts.push(...parseInline(child))
+      );
+    }
+  });
+  return richTexts;
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -128,4 +128,18 @@ const hello = "hello";
 
     expect(expected).toStrictEqual(actual);
   });
+
+  it('should convert markdown with multiple newlines to rich text', () => {
+    const text = 'hello\n\n[url](http://google.com)';
+    const actual = markdownToRichText(text);
+
+    const expected = [
+      notion.richText('hello'),
+      notion.richText('url', {
+        url: 'http://google.com',
+      }),
+    ];
+
+    expect(expected).toStrictEqual(actual);
+  });
 });


### PR DESCRIPTION
Closes #10 

There were multiple children on the root, so this was throwing an error saying that the markdown element is not supported