### PR TITLE
feat!: add checks for property value limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ import gfm from 'remark-gfm';
  */
 export function markdownToBlocks(
   body: string,
-  options: BlocksOptions
+  options?: BlocksOptions
 ): notion.Block[] {
   const root = unified().use(markdown).use(gfm).parse(body);
   return parseBlocks(root as unknown as md.Root, options);
@@ -45,7 +45,7 @@ export function markdownToBlocks(
  */
 export function markdownToRichText(
   text: string,
-  options: CommonOptions
+  options?: CommonOptions
 ): notion.RichText[] {
   const root = unified().use(markdown).use(gfm).parse(text);
   return parseRichText(root as unknown as md.Root, options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import unified from 'unified';
 import markdown from 'remark-parse';
 import type * as notion from './notion';
-import {parseBlocks, parseRichText} from './parser/internal';
+import {
+  BlocksOptions,
+  CommonOptions,
+  parseBlocks,
+  parseRichText,
+} from './parser/internal';
 import type * as md from './markdown';
 import gfm from 'remark-gfm';
 
@@ -20,14 +25,15 @@ import gfm from 'remark-gfm';
  *
  * Supports GitHub-flavoured Markdown.
  *
- * @param body any Markdown or GFM content
+ * @param body Any Markdown or GFM content
+ * @param options Any additional option
  */
 export function markdownToBlocks(
   body: string,
-  allowUnsupportedObjectType = false
+  options: BlocksOptions
 ): notion.Block[] {
   const root = unified().use(markdown).use(gfm).parse(body);
-  return parseBlocks(root as unknown as md.Root, allowUnsupportedObjectType);
+  return parseBlocks(root as unknown as md.Root, options);
 }
 
 /**
@@ -35,8 +41,12 @@ export function markdownToBlocks(
  * Only supports plain text, italics, bold, strikethrough, inline code, and hyperlinks.
  *
  * @param text any inline Markdown or GFM content
+ * @param options Any additional option
  */
-export function markdownToRichText(text: string): notion.RichText[] {
+export function markdownToRichText(
+  text: string,
+  options: CommonOptions
+): notion.RichText[] {
   const root = unified().use(markdown).use(gfm).parse(text);
-  return parseRichText(root as unknown as md.Root);
+  return parseRichText(root as unknown as md.Root, options);
 }

--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -21,7 +21,13 @@ export interface BlockText {
 export interface RichText {
   type: string;
   annotations: object;
-  text: object;
+  text: {
+    content: string;
+    link?: {
+      type: 'url';
+      url: string;
+    };
+  };
 }
 
 export function paragraph(text: RichText[]): Block {

--- a/src/notion/common.ts
+++ b/src/notion/common.ts
@@ -1,5 +1,18 @@
 import type {RichText} from './blocks';
 
+/**
+ * The limits that the Notion API uses for property values.
+ * @see https://developers.notion.com/reference/request-limits#limits-for-property-values
+ */
+export const LIMITS = {
+  RICH_TEXT_ARRAYS: 100,
+  RICH_TEXT: {
+    TEXT_CONTENT: 2000,
+    LINK_URL: 1000,
+    EQUATION_EXPRESSION: 1000,
+  },
+};
+
 export interface RichTextOptions {
   annotations?: {
     bold?: boolean;

--- a/src/notion/common.ts
+++ b/src/notion/common.ts
@@ -5,6 +5,7 @@ import type {RichText} from './blocks';
  * @see https://developers.notion.com/reference/request-limits#limits-for-property-values
  */
 export const LIMITS = {
+  PAYLOAD_BLOCKS: 1000,
   RICH_TEXT_ARRAYS: 100,
   RICH_TEXT: {
     TEXT_CONTENT: 2000,

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -215,7 +215,7 @@ export interface CommonOptions {
 
 export interface BlocksOptions extends CommonOptions {
   /** Whether to allow unsupported object types. */
-  allowUnsupportedObjectType?: boolean;
+  allowUnsupported?: boolean;
 }
 
 export function parseBlocks(
@@ -223,7 +223,7 @@ export function parseBlocks(
   options?: BlocksOptions
 ): notion.Block[] {
   const parsed = root.children.flatMap(item =>
-    parseNode(item, options?.allowUnsupportedObjectType === true)
+    parseNode(item, options?.allowUnsupported === true)
   );
 
   const truncate = !!(options?.notionLimits?.truncate ?? true),

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -222,9 +222,21 @@ export function parseBlocks(
   root: md.Root,
   options?: BlocksOptions
 ): notion.Block[] {
-  return root.children.flatMap(item =>
+  const parsed = root.children.flatMap(item =>
     parseNode(item, options?.allowUnsupportedObjectType === true)
   );
+
+  const truncate = !!(options?.notionLimits?.truncate ?? true),
+    limitCallback = options?.notionLimits?.onError ?? (() => {});
+
+  if (parsed.length > LIMITS.PAYLOAD_BLOCKS)
+    limitCallback(
+      new Error(
+        `Resulting blocks array exceeds Notion limit (${LIMITS.PAYLOAD_BLOCKS})`
+      )
+    );
+
+  return truncate ? parsed.slice(0, LIMITS.PAYLOAD_BLOCKS) : parsed;
 }
 
 export function parseRichText(

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -200,7 +200,7 @@ export interface CommonOptions {
    * Define how to behave when an item exceeds the Notion's request limits.
    * @see https://developers.notion.com/reference/request-limits#limits-for-property-values
    */
-  notionLimits: {
+  notionLimits?: {
     /**
      * Whether the excess items or characters should be automatically truncated where possible.
      * If set to `false`, the resulting item will not be compliant with Notion's limits.
@@ -218,16 +218,16 @@ export interface BlocksOptions extends CommonOptions {
 
 export function parseBlocks(
   root: md.Root,
-  options: BlocksOptions
+  options?: BlocksOptions
 ): notion.Block[] {
   return root.children.flatMap(item =>
-    parseNode(item, options.allowUnsupportedObjectType === true)
+    parseNode(item, options?.allowUnsupportedObjectType === true)
   );
 }
 
 export function parseRichText(
   root: md.Root,
-  options: CommonOptions
+  options?: CommonOptions
 ): notion.RichText[] {
   if (root.children[0].type !== 'paragraph') {
     throw new Error(`Unsupported markdown element: ${JSON.stringify(root)}`);

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -1,6 +1,7 @@
 import * as md from '../markdown';
 import * as notion from '../notion';
 import {URL} from 'url';
+import {LIMITS} from '../notion';
 
 function ensureLength(text: string, copy?: object) {
   const chunks = text.match(/[^]{1,2000}/g) || [];
@@ -56,6 +57,7 @@ function parseParagraph(element: md.Paragraph): notion.Block {
     try {
       new URL(image.url);
       return notion.image(image.url);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
       console.log(
         `${error.input} is not a valid url, I will process this as text for you to fix later`
@@ -192,14 +194,41 @@ function parseNode(node: md.FlowContent, unsupported = false): notion.Block[] {
   }
 }
 
-export function parseBlocks(
-  root: md.Root,
-  unsupported = false
-): notion.Block[] {
-  return root.children.flatMap(item => parseNode(item, unsupported));
+/** Options common to all methods. */
+export interface CommonOptions {
+  /**
+   * Define how to behave when an item exceeds the Notion's request limits.
+   * @see https://developers.notion.com/reference/request-limits#limits-for-property-values
+   */
+  notionLimits: {
+    /**
+     * Whether the excess items or characters should be automatically truncated where possible.
+     * If set to `false`, the resulting item will not be compliant with Notion's limits.
+     */
+    truncate?: boolean;
+    /** The callback for when an item exceeds Notion's limits. */
+    onError?: (err: Error) => void;
+  };
 }
 
-export function parseRichText(root: md.Root): notion.RichText[] {
+export interface BlocksOptions extends CommonOptions {
+  /** Whether to allow unsupported object types. */
+  allowUnsupportedObjectType?: boolean;
+}
+
+export function parseBlocks(
+  root: md.Root,
+  options: BlocksOptions
+): notion.Block[] {
+  return root.children.flatMap(item =>
+    parseNode(item, options.allowUnsupportedObjectType === true)
+  );
+}
+
+export function parseRichText(
+  root: md.Root,
+  options: CommonOptions
+): notion.RichText[] {
   if (root.children[0].type !== 'paragraph') {
     throw new Error(`Unsupported markdown element: ${JSON.stringify(root)}`);
   }
@@ -212,5 +241,44 @@ export function parseRichText(root: md.Root): notion.RichText[] {
       );
     }
   });
-  return richTexts;
+
+  const truncate = !!(options?.notionLimits?.truncate ?? true),
+    limitCallback = options?.notionLimits?.onError ?? (() => {});
+
+  if (richTexts.length > LIMITS.RICH_TEXT_ARRAYS)
+    limitCallback(
+      new Error(
+        `Resulting richTexts array exceeds Notion limit (${LIMITS.RICH_TEXT_ARRAYS})`
+      )
+    );
+
+  return (
+    truncate ? richTexts.slice(0, LIMITS.RICH_TEXT_ARRAYS) : richTexts
+  ).map(rt => {
+    if (rt.text.content.length > LIMITS.RICH_TEXT.TEXT_CONTENT) {
+      limitCallback(
+        new Error(
+          `Resulting text content exceeds Notion limit (${LIMITS.RICH_TEXT.TEXT_CONTENT})`
+        )
+      );
+      if (truncate)
+        rt.text.content =
+          rt.text.content.slice(0, LIMITS.RICH_TEXT.TEXT_CONTENT - 3) + '...';
+    }
+
+    if (
+      rt.text.link?.url &&
+      rt.text.link.url.length > LIMITS.RICH_TEXT.LINK_URL
+    )
+      // There's no point in truncating URLs
+      limitCallback(
+        new Error(
+          `Resulting text URL exceeds Notion limit (${LIMITS.RICH_TEXT.LINK_URL})`
+        )
+      );
+
+    // Notion equations are not supported by this library, since they don't exist in Markdown
+
+    return rt;
+  });
 }

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -204,6 +204,8 @@ export interface CommonOptions {
     /**
      * Whether the excess items or characters should be automatically truncated where possible.
      * If set to `false`, the resulting item will not be compliant with Notion's limits.
+     * Please note that text will be truncated only if the parser is not able to resolve
+     * the issue in any other way.
      */
     truncate?: boolean;
     /** The callback for when an item exceeds Notion's limits. */

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -61,8 +61,8 @@ const hello = "hello";
     const text = fs.readFileSync('test/fixtures/large-item.md').toString();
     const actual = markdownToBlocks(text);
 
-    const paragraph = actual[1].paragraph as notion.RichText;
-    const textArray = paragraph.text as Array<object>;
+    const paragraph = actual[1].paragraph as unknown as notion.RichText;
+    const textArray = paragraph.text as unknown as Array<object>;
 
     expect(textArray.length).toStrictEqual(9);
   });
@@ -85,14 +85,14 @@ const hello = "hello";
 
   it('should convert markdown to blocks - skip tables if unsupported = false', () => {
     const text = fs.readFileSync('test/fixtures/table.md').toString();
-    const actual = markdownToBlocks(text, false);
+    const actual = markdownToBlocks(text, {allowUnsupportedObjectType: false});
     const expected = [notion.headingOne([notion.richText('Table')])];
     expect(expected).toStrictEqual(actual);
   });
 
   it('should convert markdown to blocks - include tables if unsupported = true', () => {
     const text = fs.readFileSync('test/fixtures/table.md').toString();
-    const actual = markdownToBlocks(text, true);
+    const actual = markdownToBlocks(text, {allowUnsupportedObjectType: true});
     const expected = [
       notion.headingOne([notion.richText('Table')]),
       notion.table([

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -1,145 +1,192 @@
 import {markdownToBlocks, markdownToRichText} from '../src';
 import * as notion from '../src/notion';
 import fs from 'fs';
+import {LIMITS} from '../src/notion';
 
 describe('markdown converter', () => {
-  it('should convert markdown to blocks', () => {
-    const text = `
+  describe('markdownToBlocks', () => {
+    it('should convert markdown to blocks', () => {
+      const text = `
 hello _world_ 
 *** 
 ## heading2
 * [x] todo
 `;
-    const actual = markdownToBlocks(text);
+      const actual = markdownToBlocks(text);
 
-    const expected = [
-      notion.paragraph([
-        notion.richText('hello '),
-        notion.richText('world', {annotations: {italic: true}}),
-      ]),
-      notion.headingTwo([notion.richText('heading2')]),
-      notion.toDo(true, [notion.richText('todo')]),
-    ];
+      const expected = [
+        notion.paragraph([
+          notion.richText('hello '),
+          notion.richText('world', {annotations: {italic: true}}),
+        ]),
+        notion.headingTwo([notion.richText('heading2')]),
+        notion.toDo(true, [notion.richText('todo')]),
+      ];
 
-    expect(expected).toStrictEqual(actual);
-  });
+      expect(expected).toStrictEqual(actual);
+    });
 
-  it('should convert markdown to blocks - deal with code', () => {
-    const text = `
+    it('should deal with code', () => {
+      const text = `
 ## Code
 \`\`\` javascript
 const hello = "hello";
 \`\`\`
 `;
-    const actual = markdownToBlocks(text);
+      const actual = markdownToBlocks(text);
 
-    const expected = [
-      notion.headingTwo([notion.richText('Code')]),
-      notion.code([notion.richText('const hello = "hello";')]),
-    ];
+      const expected = [
+        notion.headingTwo([notion.richText('Code')]),
+        notion.code([notion.richText('const hello = "hello";')]),
+      ];
 
-    expect(expected).toStrictEqual(actual);
-  });
+      expect(expected).toStrictEqual(actual);
+    });
 
-  it('should convert markdown to blocks - deal with complex items', () => {
-    const text = fs.readFileSync('test/fixtures/complex-items.md').toString();
-    const actual = markdownToBlocks(text);
+    it('should deal with complex items', () => {
+      const text = fs.readFileSync('test/fixtures/complex-items.md').toString();
+      const actual = markdownToBlocks(text);
 
-    const expected = [
-      notion.headingOne([notion.richText('Images')]),
-      notion.paragraph([notion.richText('This is a paragraph!')]),
-      notion.blockquote([notion.richText('Quote')]),
-      notion.paragraph([notion.richText('Paragraph')]),
-      notion.image('https://url.com/image.jpg'),
-      notion.table_of_contents(),
-    ];
+      const expected = [
+        notion.headingOne([notion.richText('Images')]),
+        notion.paragraph([notion.richText('This is a paragraph!')]),
+        notion.blockquote([notion.richText('Quote')]),
+        notion.paragraph([notion.richText('Paragraph')]),
+        notion.image('https://url.com/image.jpg'),
+        notion.table_of_contents(),
+      ];
 
-    expect(expected).toStrictEqual(actual);
-  });
+      expect(expected).toStrictEqual(actual);
+    });
 
-  it('should convert markdown to blocks - break up large elements', () => {
-    const text = fs.readFileSync('test/fixtures/large-item.md').toString();
-    const actual = markdownToBlocks(text);
+    it('should break up large elements', () => {
+      const text = fs.readFileSync('test/fixtures/large-item.md').toString();
+      const actual = markdownToBlocks(text);
 
-    const paragraph = actual[1].paragraph as unknown as notion.RichText;
-    const textArray = paragraph.text as unknown as Array<object>;
+      const paragraph = actual[1].paragraph as unknown as notion.RichText;
+      const textArray = paragraph.text as unknown as Array<object>;
 
-    expect(textArray.length).toStrictEqual(9);
-  });
+      expect(textArray.length).toStrictEqual(9);
+    });
 
-  it('should convert markdown to blocks - deal with lists', () => {
-    const text = fs.readFileSync('test/fixtures/list.md').toString();
-    const actual = markdownToBlocks(text);
+    it('should deal with lists', () => {
+      const text = fs.readFileSync('test/fixtures/list.md').toString();
+      const actual = markdownToBlocks(text);
 
-    const expected = [
-      notion.headingOne([notion.richText('List')]),
-      notion.bulletedListItem(
-        [notion.richText('Item 1')],
-        [notion.bulletedListItem([notion.richText('Sub Item 1')])]
-      ),
-      notion.bulletedListItem([notion.richText('Item 2')]),
-    ];
+      const expected = [
+        notion.headingOne([notion.richText('List')]),
+        notion.bulletedListItem(
+          [notion.richText('Item 1')],
+          [notion.bulletedListItem([notion.richText('Sub Item 1')])]
+        ),
+        notion.bulletedListItem([notion.richText('Item 2')]),
+      ];
 
-    expect(expected).toStrictEqual(actual);
-  });
+      expect(expected).toStrictEqual(actual);
+    });
 
-  it('should convert markdown to blocks - skip tables if unsupported = false', () => {
-    const text = fs.readFileSync('test/fixtures/table.md').toString();
-    const actual = markdownToBlocks(text, {allowUnsupportedObjectType: false});
-    const expected = [notion.headingOne([notion.richText('Table')])];
-    expect(expected).toStrictEqual(actual);
-  });
+    it('should skip tables if unsupported = false', () => {
+      const text = fs.readFileSync('test/fixtures/table.md').toString();
+      const actual = markdownToBlocks(text, {
+        allowUnsupportedObjectType: false,
+      });
+      const expected = [notion.headingOne([notion.richText('Table')])];
+      expect(expected).toStrictEqual(actual);
+    });
 
-  it('should convert markdown to blocks - include tables if unsupported = true', () => {
-    const text = fs.readFileSync('test/fixtures/table.md').toString();
-    const actual = markdownToBlocks(text, {allowUnsupportedObjectType: true});
-    const expected = [
-      notion.headingOne([notion.richText('Table')]),
-      notion.table([
-        notion.tableRow([
-          notion.tableCell([notion.richText('First Header')]),
-          notion.tableCell([notion.richText('Second Header')]),
+    it('should include tables if unsupported = true', () => {
+      const text = fs.readFileSync('test/fixtures/table.md').toString();
+      const actual = markdownToBlocks(text, {allowUnsupportedObjectType: true});
+      const expected = [
+        notion.headingOne([notion.richText('Table')]),
+        notion.table([
+          notion.tableRow([
+            notion.tableCell([notion.richText('First Header')]),
+            notion.tableCell([notion.richText('Second Header')]),
+          ]),
+          notion.tableRow([
+            notion.tableCell([notion.richText('Content Cell')]),
+            notion.tableCell([notion.richText('Content Cell')]),
+          ]),
+          notion.tableRow([
+            notion.tableCell([notion.richText('Content Cell')]),
+            notion.tableCell([notion.richText('Content Cell')]),
+          ]),
         ]),
-        notion.tableRow([
-          notion.tableCell([notion.richText('Content Cell')]),
-          notion.tableCell([notion.richText('Content Cell')]),
-        ]),
-        notion.tableRow([
-          notion.tableCell([notion.richText('Content Cell')]),
-          notion.tableCell([notion.richText('Content Cell')]),
-        ]),
-      ]),
-    ];
+      ];
 
-    expect(expected).toStrictEqual(actual);
+      expect(expected).toStrictEqual(actual);
+    });
   });
 
-  it('should convert markdown to rich text', () => {
-    const text = 'hello [_url_](https://example.com)';
-    const actual = markdownToRichText(text);
+  describe('markdownToRichText', () => {
+    it('should convert markdown to rich text', () => {
+      const text = 'hello [_url_](https://example.com)';
+      const actual = markdownToRichText(text);
 
-    const expected = [
-      notion.richText('hello '),
-      notion.richText('url', {
-        annotations: {italic: true},
-        url: 'https://example.com',
-      }),
-    ];
+      const expected = [
+        notion.richText('hello '),
+        notion.richText('url', {
+          annotations: {italic: true},
+          url: 'https://example.com',
+        }),
+      ];
 
-    expect(expected).toStrictEqual(actual);
-  });
+      expect(expected).toStrictEqual(actual);
+    });
 
-  it('should convert markdown with multiple newlines to rich text', () => {
-    const text = 'hello\n\n[url](http://google.com)';
-    const actual = markdownToRichText(text);
+    it('should convert markdown with multiple newlines to rich text', () => {
+      const text = 'hello\n\n[url](http://google.com)';
+      const actual = markdownToRichText(text);
 
-    const expected = [
-      notion.richText('hello'),
-      notion.richText('url', {
-        url: 'http://google.com',
-      }),
-    ];
+      const expected = [
+        notion.richText('hello'),
+        notion.richText('url', {
+          url: 'http://google.com',
+        }),
+      ];
 
-    expect(expected).toStrictEqual(actual);
+      expect(expected).toStrictEqual(actual);
+    });
+
+    it('should truncate items when options.notionLimits.truncate = true', () => {
+      const text = Array(LIMITS.RICH_TEXT_ARRAYS + 10)
+        .fill('a *a* ')
+        .join('');
+
+      const actual = {
+        default: markdownToRichText(text),
+        explicit: markdownToRichText(text, {notionLimits: {truncate: true}}),
+      };
+
+      expect(actual.default.length).toBe(LIMITS.RICH_TEXT_ARRAYS);
+      expect(actual.explicit.length).toBe(LIMITS.RICH_TEXT_ARRAYS);
+    });
+
+    it('should not truncate items when options.notionLimits.truncate = false', () => {
+      const text = Array(LIMITS.RICH_TEXT_ARRAYS + 10)
+        .fill('a *a* ')
+        .join('');
+
+      const actual = markdownToRichText(text, {
+        notionLimits: {truncate: false},
+      });
+
+      expect(actual.length).toBeGreaterThan(LIMITS.RICH_TEXT_ARRAYS);
+    });
+
+    it('should call the callback when options.notionLimits.onError is defined', () => {
+      const text = Array(LIMITS.RICH_TEXT_ARRAYS + 10)
+        .fill('a *a* ')
+        .join('');
+      const spy = jest.fn();
+
+      markdownToRichText(text, {
+        notionLimits: {onError: spy},
+      });
+
+      expect(spy).toBeCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith(expect.any(Error));
+    });
   });
 });

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -88,7 +88,7 @@ const hello = "hello";
     it('should skip tables if unsupported = false', () => {
       const text = fs.readFileSync('test/fixtures/table.md').toString();
       const actual = markdownToBlocks(text, {
-        allowUnsupportedObjectType: false,
+        allowUnsupported: false,
       });
       const expected = [notion.headingOne([notion.richText('Table')])];
       expect(expected).toStrictEqual(actual);
@@ -96,7 +96,7 @@ const hello = "hello";
 
     it('should include tables if unsupported = true', () => {
       const text = fs.readFileSync('test/fixtures/table.md').toString();
-      const actual = markdownToBlocks(text, {allowUnsupportedObjectType: true});
+      const actual = markdownToBlocks(text, {allowUnsupported: true});
       const expected = [
         notion.headingOne([notion.richText('Table')]),
         notion.table([


### PR DESCRIPTION
Closes #6 

This PR adds a way to control what happens when an item does not respect Notion's API limitation.
Items can be truncated and you can pass a callback for when it happens, so that you can decide what to do.

Please note that the system for distributing rich text into multiple items is still in place, and should be able to handle most of the work without having to truncate text.

**Breaking changes**:
- The `unsupported` option of `markdownToBlocks` is now part of the `options` object