### PR TITLE
Change text block name to rich_text

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ const blocks: Block[] = markdownToBlocks(`
 //     "object": "block",
 //     "type": "heading_1",
 //     "heading_1": {
-//       "text": [
+//       "rich_text": [
 //         {
 //           "type": "text",
 //           "annotations": {

--- a/README.md
+++ b/README.md
@@ -11,33 +11,36 @@ Martian is a Markdown parser to convert any Markdown content to Notion API block
 uses [unified](https://github.com/unifiedjs/unified) to create a Markdown AST, then converts the AST into Notion
 objects.
 
-Designed to make using the Notion SDK and API easier.  Notion API version 0.4.5.
+Designed to make using the Notion SDK and API easier. Notion API version 0.4.5.
 
 ### Supported Markdown Elements
 
-* All inline elements (italics, bold, strikethrough, inline code, hyperlinks)
-* Lists (ordered, unordered, checkboxes) - to any level of depth
-* All headers (header levels >= 3 are treated as header level 3)
-* Code blocks
-* Block quotes
-* Images (where the image is the first element in the paragraph and it has a valid full URL)
+- All inline elements (italics, bold, strikethrough, inline code, hyperlinks)
+- Lists (ordered, unordered, checkboxes) - to any level of depth
+- All headers (header levels >= 3 are treated as header level 3)
+- Code blocks
+- Block quotes
+- Images (where the image is the first element in the paragraph and it has a valid full URL)
 
 ## Unsupported Markdown Elements
 
-*tables*: Tables can be imported in an [unsupported mode](https://developers.notion.com/reference/block) if you add a flag to the parser.
+_tables_: Tables can be imported in an [unsupported mode](https://developers.notion.com/reference/block) if you add a flag to the parser.
 
 First, the default mode - it ignores the tables:
 
 ```ts
 const allowUnsupportedObjectType = false;
-const blocks: Block[] = markdownToBlocks(`
+const blocks: Block[] = markdownToBlocks(
+  `
 # Table
 
 | First Header  | Second Header |
 | ------------- | ------------- |
 | Content Cell  | Content Cell  |
 | Content Cell  | Content Cell  |
-`, allowUnsupportedObjectType);
+`,
+  allowUnsupportedObjectType
+);
 
 // [
 //   {
@@ -67,7 +70,6 @@ const blocks: Block[] = markdownToBlocks(`
 
 Next, with unsupported flag = true (note the `annotations` have been removed from the returned object to make it easier to see what is going on):
 
-
 ```ts
 const allowUnsupportedObjectType = true;
 const blocks: Block[] = markdownToBlocks(`
@@ -84,7 +86,7 @@ const blocks: Block[] = markdownToBlocks(`
 //     "object": "block",
 //     "type": "heading_1",
 //     "heading_1": {
-//       "text": [
+//       "rich_text": [
 //         {
 //           "type": "text",
 //           "text": {
@@ -213,8 +215,7 @@ const blocks: Block[] = markdownToBlocks(`
 // ]
 ```
 
-Note that if you send this document to Notion with the current version of the API it *will* fail, but this allows you to pre-parse the blocks in your client library, and do something with the tables.  In one example, the tables are being parsed out of the blocks, databases being created, that are then linked back to the imported page:  https://github.com/infinitaslearning/notionater/blob/main/index.js#L81-L203
-
+Note that if you send this document to Notion with the current version of the API it _will_ fail, but this allows you to pre-parse the blocks in your client library, and do something with the tables. In one example, the tables are being parsed out of the blocks, databases being created, that are then linked back to the imported page: https://github.com/infinitaslearning/notionater/blob/main/index.js#L81-L203
 
 ## Usage
 
@@ -246,19 +247,18 @@ const richText: RichText[] = markdownToRichText(`**Hello _world_**`);
 //   }
 // ]
 
-
 const blocks: Block[] = markdownToBlocks(`
 ## this is a _heading 2_
 
 * [x] todo list item
-`)
+`);
 
 // [
 //   {
 //     "object": "block",
 //     "type": "heading_2",
 //     "heading_2": {
-//       "text": [
+//       "rich_text": [
 //         ...
 //         {
 //           "type": "text",
@@ -276,7 +276,7 @@ const blocks: Block[] = markdownToBlocks(`
 //     "object": "block",
 //     "type": "to_do",
 //     "to_do": {
-//       "text": [
+//       "rich_text": [
 //         {
 //           "type": "text",
 //           "annotations": {

--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -15,7 +15,7 @@ export interface Block {
 }
 
 export interface BlockText {
-  text: RichText[];
+  rich_text: RichText[];
 }
 
 export interface RichText {
@@ -35,7 +35,7 @@ export function paragraph(text: RichText[]): Block {
     object: 'block',
     type: 'paragraph',
     paragraph: {
-      text: text,
+      rich_text: text,
     },
   } as Block;
 }
@@ -45,7 +45,7 @@ export function code(text: RichText[]): Block {
     object: 'block',
     type: 'code',
     code: {
-      text: text,
+      rich_text: text,
       language: 'javascript',
     },
   } as Block;
@@ -56,7 +56,7 @@ export function blockquote(text: RichText[]): Block {
     object: 'block',
     type: 'quote',
     quote: {
-      text: text,
+      rich_text: text,
     },
   } as Block;
 }
@@ -87,7 +87,7 @@ export function headingOne(text: RichText[]): Block {
     object: 'block',
     type: 'heading_1',
     heading_1: {
-      text: text,
+      rich_text: text,
     },
   } as Block;
 }
@@ -97,7 +97,7 @@ export function headingTwo(text: RichText[]): Block {
     object: 'block',
     type: 'heading_2',
     heading_2: {
-      text: text,
+      rich_text: text,
     },
   } as Block;
 }
@@ -107,7 +107,7 @@ export function headingThree(text: RichText[]): Block {
     object: 'block',
     type: 'heading_3',
     heading_3: {
-      text: text,
+      rich_text: text,
     },
   } as Block;
 }
@@ -120,7 +120,7 @@ export function bulletedListItem(
     object: 'block',
     type: 'bulleted_list_item',
     bulleted_list_item: {
-      text: text,
+      rich_text: text,
       children: children.length ? children : undefined,
     },
   } as Block;
@@ -134,7 +134,7 @@ export function numberedListItem(
     object: 'block',
     type: 'numbered_list_item',
     numbered_list_item: {
-      text: text,
+      rich_text: text,
       children: children.length ? children : undefined,
     },
   } as Block;
@@ -149,7 +149,7 @@ export function toDo(
     object: 'block',
     type: 'to_do',
     to_do: {
-      text: text,
+      rich_text: text,
       checked: checked,
       children: children.length ? children : undefined,
     },

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -90,16 +90,16 @@ function parseBlockquote(element: md.Blockquote): notion.Block {
   const paragraphs = blocks.flatMap(child => child as notion.Block);
   const richtext = paragraphs.flatMap(child => {
     if (child.paragraph) {
-      return child.paragraph.text as notion.RichText[];
+      return child.paragraph.rich_text as notion.RichText[];
     }
     if (child.heading_1) {
-      return child.heading_1.text as notion.RichText[];
+      return child.heading_1.rich_text as notion.RichText[];
     }
     if (child.heading_2) {
-      return child.heading_2.text as notion.RichText[];
+      return child.heading_2.rich_text as notion.RichText[];
     }
     if (child.heading_3) {
-      return child.heading_3.text as notion.RichText[];
+      return child.heading_3.rich_text as notion.RichText[];
     }
     return [];
   });

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -63,8 +63,8 @@ const hello = "hello";
       const text = fs.readFileSync('test/fixtures/large-item.md').toString();
       const actual = markdownToBlocks(text);
 
-      const paragraph = actual[1].paragraph as unknown as notion.RichText;
-      const textArray = paragraph.text as unknown as Array<object>;
+      const paragraph = actual[1].paragraph as unknown as notion.BlockText;
+      const textArray = paragraph.rich_text as unknown as Array<object>;
 
       expect(textArray.length).toStrictEqual(9);
     });


### PR DESCRIPTION
Notion API Version: 2022-02-22 has renamed the
property of their rich text blocks from "text" to "rich_text".

https://developers.notion.com/changelog/releasing-notion-version-2022-02-22