### PR TITLE
fix: code block language

### DIFF
--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -40,13 +40,13 @@ export function paragraph(text: RichText[]): Block {
   } as Block;
 }
 
-export function code(text: RichText[]): Block {
+export function code(text: RichText[], lang?: String): Block {
   return {
     object: 'block',
     type: 'code',
     code: {
       rich_text: text,
-      language: 'javascript',
+      language: lang || 'javascript',
     },
   } as Block;
 }

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -123,7 +123,7 @@ function parseHeading(element: md.Heading): notion.Block {
 
 function parseCode(element: md.Code): notion.Block {
   const text = ensureLength(element.value);
-  return notion.code(text);
+  return notion.code(text, element.lang);
 }
 
 function parseList(element: md.List): notion.Block[] {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -32,12 +32,16 @@ hello _world_
 \`\`\` javascript
 const hello = "hello";
 \`\`\`
+\`\`\` python
+print("hello")
+\`\`\`
 `;
       const actual = markdownToBlocks(text);
 
       const expected = [
         notion.headingTwo([notion.richText('Code')]),
         notion.code([notion.richText('const hello = "hello";')]),
+        notion.code([notion.richText('print("hello")')], 'python'),
       ];
 
       expect(expected).toStrictEqual(actual);

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -114,7 +114,7 @@ describe('gfm parser', () => {
 
     const expected = [
       notion.paragraph([notion.richText('hello')]),
-      notion.code([notion.richText('public class Foo {}')]),
+      notion.code([notion.richText('public class Foo {}')], 'java'),
     ];
 
     expect(actual).toStrictEqual(expected);


### PR DESCRIPTION
Function `code` in `block.ts` will treat all code language as javascript.

Actually every code block's language is javascript. Fix this by using `element.lang` as code language.