### PR TITLE
fix: support children of quote blocks

### DIFF
--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -1,4 +1,4 @@
-import {supportedCodeLang} from './common';
+import {richText, supportedCodeLang} from './common';
 import {AppendBlockChildrenParameters} from '@notionhq/client/build/src/api-endpoints';
 
 export type Block = AppendBlockChildrenParameters['children'][number];
@@ -36,12 +36,18 @@ export function code(
   };
 }
 
-export function blockquote(text: RichText[]): Block {
+export function blockquote(
+  text: RichText[] = [],
+  children: Block[] = []
+): Block {
   return {
     object: 'block',
     type: 'quote',
     quote: {
-      rich_text: text,
+      // By setting an empty rich text we prevent the "Empty quote" line from showing up at all
+      rich_text: text.length ? text : [richText('')],
+      // @ts-expect-error Typings are not perfect
+      children,
     },
   };
 }

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -140,26 +140,8 @@ function parseBlockquote(
   element: md.Blockquote,
   options: BlocksOptions
 ): notion.Block {
-  // Quotes can only contain RichText[], but come through as Block[]
-  // This code collects and flattens the common ones
-  const blocks = element.children.flatMap(child => parseNode(child, options));
-  const paragraphs = blocks.flatMap(child => child as notion.Block);
-  const richtext = paragraphs.flatMap(child => {
-    if (child.type === 'paragraph') {
-      return child.paragraph.rich_text as notion.RichText[];
-    }
-    if (child.type === 'heading_1') {
-      return child.heading_1.rich_text as notion.RichText[];
-    }
-    if (child.type === 'heading_2') {
-      return child.heading_2.rich_text as notion.RichText[];
-    }
-    if (child.type === 'heading_3') {
-      return child.heading_3.rich_text as notion.RichText[];
-    }
-    return [];
-  });
-  return notion.blockquote(richtext as notion.RichText[]);
+  const children = element.children.flatMap(child => parseNode(child, options));
+  return notion.blockquote([], children);
 }
 
 function parseHeading(element: md.Heading): notion.Block {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -84,7 +84,7 @@ const hello = "hello";
       const expected = [
         notion.headingOne([notion.richText('Images')]),
         notion.paragraph([notion.richText('This is a paragraph!')]),
-        notion.blockquote([notion.richText('Quote')]),
+        notion.blockquote([], [notion.paragraph([notion.richText('Quote')])]),
         notion.paragraph([notion.richText('Paragraph')]),
         notion.image('https://url.com/image.jpg'),
         notion.table_of_contents(),

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -162,12 +162,17 @@ describe('gfm parser', () => {
     const actual = parseBlocks(ast, options);
 
     const expected = [
-      notion.blockquote([
-        notion.richText('hello'),
-        notion.richText('world', {
-          annotations: {italic: true},
-        }),
-      ]),
+      notion.blockquote(
+        [],
+        [
+          notion.headingOne([
+            notion.richText('hello'),
+            notion.richText('world', {
+              annotations: {italic: true},
+            }),
+          ]),
+        ]
+      ),
     ];
 
     expect(actual).toStrictEqual(expected);


### PR DESCRIPTION
This PR closes #29 
We were previously converting a selection of blocks to rich text, to put inside the quote block.
I first tried to expand the list of supported blocks to almost everyone but the result was not ideal. While testing I ended up finding that if we set a rich text block with empty content, Notion won't display the "Empty quote" box before the children.
I think this is the optimal way to handle quote blocks since we're setting the children without compromising on formatting.

Quote block without any rich text element:
<img width="140" alt="image" src="https://user-images.githubusercontent.com/26386270/167670032-e4768054-456a-4f04-b42d-1f4bdce37f8f.png">

Quote block with the empty rich text element:
<img width="105" alt="image" src="https://user-images.githubusercontent.com/26386270/167670153-9b3a45d0-4411-4ad9-9cc1-bc1f0655773e.png">
