### PR TITLE
Added in support for nested quotes

### DIFF
--- a/src/notion/blocks.ts
+++ b/src/notion/blocks.ts
@@ -36,12 +36,16 @@ export function code(
   };
 }
 
-export function blockquote(text: RichText[]): Block {
+export function blockquote(
+  text: RichText[],
+  children: BlockWithoutChildren[] = []
+): Block {
   return {
     object: 'block',
     type: 'quote',
     quote: {
       rich_text: text,
+      children: children.length ? children : undefined,
     },
   };
 }

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -144,7 +144,7 @@ function parseBlockquote(
   // This code collects and flattens the common ones
   const blocks = element.children.flatMap(child => parseNode(child, options));
   const paragraphs = blocks.flatMap(child => child as notion.Block);
-  const richtext = paragraphs.flatMap(child => {
+  const getRichtext = (child: notion.Block) => {
     if (child.type === 'paragraph') {
       return child.paragraph.rich_text as notion.RichText[];
     }
@@ -158,8 +158,10 @@ function parseBlockquote(
       return child.heading_3.rich_text as notion.RichText[];
     }
     return [];
-  });
-  return notion.blockquote(richtext as notion.RichText[]);
+  };
+  const richtext = paragraphs.length > 0 ? getRichtext(paragraphs[0]) : [];
+  const children = (paragraphs.length > 1 ? paragraphs.slice(1) : []) as notion.BlockWithoutChildren[];
+  return notion.blockquote(richtext as notion.RichText[], children);
 }
 
 function parseHeading(element: md.Heading): notion.Block {


### PR DESCRIPTION
While the Notion interface does not allow users to add nested blocks inside of quotes their API does. This PR adds in support for fully nested children within quotes and I have verified that everything works fine in Notion after adding nested blocks to a quote. Checkout the screenshot below to see what the results look like in Notion.
<img width="334" alt="Screen Shot 2022-05-10 at 2 04 34 PM" src="https://user-images.githubusercontent.com/3848969/167721939-8f677214-200f-4db9-b6b8-8d0801b95752.png">

I was driven to make this change because I noticed that the paragraphs inside of our quotes were being appended to each other without any newlines. This change seemed like a better fix since it deals with all nesting levels.
