### PR TITLE
Officially support tables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,18 +13,6 @@ import remarkMath from 'remark-math';
 
 /**
  * Parses Markdown content into Notion Blocks.
- * - Supports all heading types (heading depths 4, 5, 6 are treated as 3 for Notion)
- * - Supports numbered lists, bulleted lists, to-do lists
- * - Supports italics, bold, strikethrough, inline code, hyperlinks
- *
- * Per Notion limitations, these markdown attributes are not supported:
- * - Tables (removed)
- * - HTML tags (removed)
- * - Thematic breaks (removed)
- * - Code blocks (treated as paragraph)
- * - Block quotes (treated as paragraph)
- *
- * Supports GitHub-flavoured Markdown.
  *
  * @param body Any Markdown or GFM content
  * @param options Any additional option

--- a/src/parser/internal.ts
+++ b/src/parser/internal.ts
@@ -253,11 +253,7 @@ function parseNode(
       return parseList(node, options);
 
     case 'table':
-      if (options.allowUnsupported) {
-        return parseTable(node);
-      } else {
-        return [];
-      }
+      return parseTable(node);
 
     case 'math':
       return [parseMath(node)];
@@ -287,9 +283,6 @@ export interface CommonOptions {
 }
 
 export interface BlocksOptions extends CommonOptions {
-  /** Whether to allow unsupported object types. */
-  allowUnsupported?: boolean;
-
   /** Whether to render invalid images as text */
   strictImageUrls?: boolean;
 }

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -146,7 +146,7 @@ const hello = "hello";
         ),
       ];
 
-      expect(expected).toStrictEqual(actual);
+      expect(actual).toStrictEqual(expected);
     });
 
     it('should convert markdown to blocks - deal with images - strict mode', () => {
@@ -164,7 +164,7 @@ const hello = "hello";
         notion.paragraph([notion.richText('https://image.com/blah')]),
       ];
 
-      expect(expected).toStrictEqual(actual);
+      expect(actual).toStrictEqual(expected);
     });
 
     it('should convert markdown to blocks - deal with images - not strict mode', () => {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -122,18 +122,9 @@ const hello = "hello";
       expect(actual).toStrictEqual(expected);
     });
 
-    it('should skip tables if unsupported = false', () => {
+    it('should deal with tables', () => {
       const text = fs.readFileSync('test/fixtures/table.md').toString();
-      const actual = markdownToBlocks(text, {
-        allowUnsupported: false,
-      });
-      const expected = [notion.headingOne([notion.richText('Table')])];
-      expect(actual).toStrictEqual(expected);
-    });
-
-    it('should include tables if unsupported = true', () => {
-      const text = fs.readFileSync('test/fixtures/table.md').toString();
-      const actual = markdownToBlocks(text, {allowUnsupported: true});
+      const actual = markdownToBlocks(text);
       const expected = [
         notion.headingOne([notion.richText('Table')]),
         notion.table(

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -234,6 +234,17 @@ describe('gfm parser', () => {
           annotations: {strikethrough: true},
         }),
       ]),
+      notion.table(
+        [
+          notion.tableRow([
+            [notion.richText('a')],
+            [notion.richText('b')],
+            [notion.richText('c')],
+            [notion.richText('d')],
+          ]),
+        ],
+        4
+      ),
       notion.toDo(false, [notion.richText('to do')]),
       notion.toDo(true, [notion.richText('done')]),
     ];


### PR DESCRIPTION
Tables will be now parsed by default.
The `allowUnsupported` option has been removed, since we don't have any unsupported element left.
I've also re-written the README, which had outdated info on how to use the package.

Closes #30 