### PR TITLE
feat: add `nonInline` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,3 +286,52 @@ markdownToBlocks('![](InvalidURL)', {
 Built with 💙 by the team behind [Fabric](https://tryfabric.com).
 
 <img src="https://static.scarf.sh/a.png?x-pxid=79ae4e0a-7e48-4965-8a83-808c009aa47a" />
+
+### Non-inline elements when parsing rich text
+
+By default, if the text provided to `markdownToRichText` would result in one or more non-inline elements, the package will ignore those and only parse paragraphs.  
+You can make the package throw an error when a non-inline element is detected by setting the `nonInline` option to `'throw'`.
+
+Default behavior:
+
+```ts
+markdownToRichText('# Header\nAbc', {
+  // nonInline: 'ignore', // Default
+});
+```
+
+<details>
+<summary>Result</summary>
+<pre>
+[
+  {
+    type: 'text',
+    annotations: {
+      bold: false,
+      strikethrough: false,
+      underline: false,
+      italic: false,
+      code: false,
+      color: 'default'
+    },
+    text: { content: 'Abc', link: undefined }
+  }
+]
+</pre>
+</details>
+
+Throw an error:
+
+```ts
+markdownToRichText('# Header\nAbc', {
+  nonInline: 'throw',
+});
+```
+
+<details>
+<summary>Result</summary>
+<pre>
+Error: Unsupported markdown element: {"type":"heading","depth":1,"children":[{"type":"text","value":"Header","position":{"start":{"line":1,"column":3,
+"offset":2},"end":{"line":1,"column":9,"offset":8}}}],"position":{"start":{"line":1,"column":1,"offset":0},"end":{"line":1,"column":9,"offset":8}}}  
+</pre>
+</details>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ markdownToRichText(`**Hello _world_**`);
 
 <details>
 <summary>Result</summary>
-<pre><code>[
+<pre>
+[
   {
     "type": "text",
     "annotations": {
@@ -74,7 +75,8 @@ markdownToRichText(`**Hello _world_**`);
       "content": "world"
     }
   }
-]</code></pre>
+]
+</pre>
 </details>
 
 ```ts
@@ -88,7 +90,8 @@ hello _world_
 
 <details>
 <summary>Result</summary>
-<pre><code>[
+<pre>
+[
   {
     "object": "block",
     "type": "paragraph",
@@ -170,7 +173,8 @@ hello _world_
       "checked": true
     }
   }
-]</code></pre>
+]
+</pre>
 </details>
 
 ### Working with Notion's limits
@@ -231,7 +235,8 @@ markdownToBlocks('![](InvalidURL)');
 
 <details>
 <summary>Result</summary>
-<pre><code>[
+<pre>
+[
   {
     "object": "block",
     "type": "paragraph",
@@ -254,7 +259,8 @@ markdownToBlocks('![](InvalidURL)');
       ]
     }
   }
-]</code></pre>
+]
+</pre>
 </details>
 
 `strictImageUrls` disabled:
@@ -267,7 +273,8 @@ markdownToBlocks('![](InvalidURL)', {
 
 <details>
 <summary>Result</summary>
-<pre><code>[
+<pre>
+[
   {
     "object": "block",
     "type": "image",
@@ -278,7 +285,8 @@ markdownToBlocks('![](InvalidURL)', {
       }
     }
   }
-]</code></pre>
+]
+</pre>
 </details>
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@ import markdown from 'remark-parse';
 import type * as notion from './notion';
 import {
   BlocksOptions,
-  CommonOptions,
   parseBlocks,
   parseRichText,
+  RichTextOptions,
 } from './parser/internal';
 import type * as md from './markdown';
 import gfm from 'remark-gfm';
@@ -47,7 +47,7 @@ export function markdownToBlocks(
  */
 export function markdownToRichText(
   text: string,
-  options?: CommonOptions
+  options?: RichTextOptions
 ): notion.RichText[] {
   const root = unified().use(markdown).use(gfm).parse(text);
   return parseRichText(root as unknown as md.Root, options);

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -282,5 +282,37 @@ const hello = "hello";
       expect(spy).toBeCalledTimes(1);
       expect(spy).toHaveBeenCalledWith(expect.any(Error));
     });
+
+    it('should ignore unsupported elements by default', () => {
+      const text1 = '# Header first\nOther text',
+        text2 = 'Other text\n# Header second';
+
+      const actual1 = markdownToRichText(text1),
+        actual2 = markdownToRichText(text2);
+
+      const expected = [notion.richText('Other text')];
+
+      expect(actual1).toStrictEqual(expected);
+      expect(actual2).toStrictEqual(expected);
+    });
+
+    it("should ignore unsupported elements when nonInline = 'ignore'", () => {
+      const text = '# Header first\nOther text';
+
+      const actual = markdownToRichText(text, {nonInline: 'ignore'});
+
+      const expected = [notion.richText('Other text')];
+
+      expect(actual).toStrictEqual(expected);
+    });
+
+    it("should throw when there's an unsupported element and nonInline = 'throw'", () => {
+      const text = '# Header first\nOther text';
+
+      expect(() => markdownToRichText(text, {nonInline: 'throw'})).toThrow();
+      expect(() =>
+        markdownToRichText(text, {nonInline: 'ignore'})
+      ).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
This PR adds an option that lets you choose how the package should handle non-inline elements when using `markdownToRichText`

- [x] Code
- [x] Tests
- [x] Docs: waiting for #36 to get merged, so I can add docs to the new README